### PR TITLE
Allow courseid in placeholders and enable sending notifications for deleted courses

### DIFF
--- a/classes/lifecycle/step.php
+++ b/classes/lifecycle/step.php
@@ -153,7 +153,7 @@ class step extends libbase {
 
             // Replace course short name.
             $patterns[] = '##courseshortname##';
-            $replacements[] = '';
+            $replacements[] = 'Course short name not found';
 
             // Replace course short name.
             $patterns[] = '##courseid##';
@@ -161,7 +161,7 @@ class step extends libbase {
 
             // Replace course full name.
             $patterns[] = '##coursefullname##';
-            $replacements[] = '';
+            $replacements[] = 'Course full name not found';
 
         }
 

--- a/lang/en/tool_lcnotificationstep.php
+++ b/lang/en/tool_lcnotificationstep.php
@@ -31,6 +31,7 @@ $string['emptyroles'] = 'Roles must not be empty.';
 $placeholder = '<p>' . 'You can use the following placeholders:'
     . '<br>' . 'Course short name: ##courseshortname##'
     . '<br>' . 'Course fullname : ##coursefullname##'
+    . '<br>' . 'Course id : ##courseid##'
     . '<br>' . 'Current date: ##currentdate##'
     . '<br>' . 'User first name: ##userfirstname##'
     . '<br>' . 'User last name: ##userlastname##'

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -183,4 +183,46 @@ class step_test extends \advanced_testcase {
         $this->assertStringContainsString('Plain content ' . $this->course->fullname, quoted_printable_decode($email->body));
         $this->assertStringContainsString('HTML content ' . $this->course->fullname, quoted_printable_decode($email->body));
     }
+
+    /**
+     * Test notification sends when course no longer exists.
+     */
+    public function test_notification_step_for_random_courseid() {
+        $this->resetAfterTest();
+
+        $randomcourseid = 12;
+
+        ob_start();
+
+        settings_manager::save_settings($this->stepid, settings_type::STEP,
+            "tool_lcnotificationstep",
+            [
+                "roles" => "",
+                "emails" => 'external@email.com',
+                "subject" => 'Subject ##courseid##',
+                "content" => 'Plain content ##userfirstname## ##userlastname## ##courseid##',
+                "contenthtml" => 'HTML content ##userfirstname## ##userlastname## ##courseid##',
+            ]
+        );
+
+        // Run trigger.
+        process_manager::manually_trigger_process($randomcourseid, $this->trigger->id);
+
+        // Check that email was sent.
+        $sink = $this->redirectEmails();
+        $processor = new processor();
+        $processor->process_courses();
+        $emails = $sink->get_messages();
+
+        ob_end_clean();
+
+        $this->assertCount(1, $emails);
+
+        // External Email.
+        $email = $emails[0];
+        $this->assertEquals('external@email.com', $email->to);
+        $this->assertEquals('Subject ' . $randomcourseid, $email->subject);
+        $this->assertStringContainsString('Plain content ' . $randomcourseid, quoted_printable_decode($email->body));
+        $this->assertStringContainsString('HTML content ' . $randomcourseid, quoted_printable_decode($email->body));
+    }
 }


### PR DESCRIPTION
This PR adds support for including the courseid in placeholders and enables notifications to be sent even when the course no longer exists.