### PR TITLE
Fix editor field not loading contenthtml in lifecycle step form

### DIFF
--- a/classes/lifecycle/step.php
+++ b/classes/lifecycle/step.php
@@ -231,4 +231,15 @@ class step extends libbase {
         $mform->addHelpButton($elementname, 'email_content_html', 'tool_lcnotificationstep');
         $mform->setType($elementname, PARAM_RAW);
     }
+
+    /**
+     * This method can be overriden, to set default values to the form_step_instance.
+     * It is called in definition_after_data().
+     * @param \MoodleQuickForm $mform
+     * @param array $settings array containing the settings from the db.
+     */
+    public function extend_add_instance_form_definition_after_data($mform, $settings) {
+        $mform->setDefault('contenthtml',
+                ['text' => isset($settings['contenthtml']) ? $settings['contenthtml'] : '', 'format' => FORMAT_HTML]);
+    }
 }


### PR DESCRIPTION
This PR fixes the issue where the contenthtml editor field was not displaying saved data properly in the lifecycle step form. This change formats the value correctly so the editor can render it.

After adding the fix: 
![Screenshot from 2025-05-08 15-46-52](https://github.com/user-attachments/assets/8e12a77e-ad40-4f63-8eec-b0b0b4a61b7e)

